### PR TITLE
Prevent puppet applying the `Nexus3_repository` resource `depth` on every run

### DIFF
--- a/lib/puppet/provider/nexus3_repository/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/read_config.erb
@@ -31,7 +31,7 @@ def infos = repositories.findResults { repository ->
     remote_password: authentication.get('password'),
     remote_ntlm_host: authentication.get('ntlmHost'),
     remote_ntlm_domain: authentication.get('ntlmDomain'),
-    depth: yum.get('repodataDepth'),
+    depth: yum.get('repodataDepth').empty? ? 0 : yum.get('repodataDepth'),
     httpport: docker.get('httpPort'),
     httpsport: docker.get('httpsPort'),
     v1enabled: docker.get('v1Enabled'),

--- a/lib/puppet/provider/nexus3_repository/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/read_config.erb
@@ -31,7 +31,7 @@ def infos = repositories.findResults { repository ->
     remote_password: authentication.get('password'),
     remote_ntlm_host: authentication.get('ntlmHost'),
     remote_ntlm_domain: authentication.get('ntlmDomain'),
-    depth: yum.get('repodataDepth').empty? ? '0' : yum.get('repodataDepth'),
+    depth: yum.get('repodataDepth') ? yum.get('repodataDepth') : '0',
     httpport: docker.get('httpPort'),
     httpsport: docker.get('httpsPort'),
     v1enabled: docker.get('v1Enabled'),

--- a/lib/puppet/provider/nexus3_repository/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/read_config.erb
@@ -31,7 +31,7 @@ def infos = repositories.findResults { repository ->
     remote_password: authentication.get('password'),
     remote_ntlm_host: authentication.get('ntlmHost'),
     remote_ntlm_domain: authentication.get('ntlmDomain'),
-    depth: yum.get('repodataDepth').empty? ? 0 : yum.get('repodataDepth'),
+    depth: yum.get('repodataDepth').empty? ? '0' : yum.get('repodataDepth'),
     httpport: docker.get('httpPort'),
     httpsport: docker.get('httpsPort'),
     v1enabled: docker.get('v1Enabled'),


### PR DESCRIPTION
The `depth` attribute is only needed for Yum repos. It is redundant for repos such as Nuget.

When puppet runs, the `Nexus3_repository` resource is always trying to change the `depth` attribute of the repo, when this value is irrelevant for repos like NuGet:

```
Notice: /Stage[main]/Profile::Linux::Nexus::Server/Nexus3_repository[nuget-packages]/depth: depth changed '' to '0'
Notice: /Stage[main]/Profile::Linux::Nexus::Server/Nexus3_repository[legacy-components]/depth: depth changed '' to '0'
Notice: /Stage[main]/Profile::Linux::Nexus::Server/Nexus3_repository[legacy-foo]/depth: depth changed '' to '0'
Notice: /Stage[main]/Profile::Linux::Nexus::Server/Nexus3_repository[nuget-components]/depth: depth changed '' to '0'
Notice: /Stage[main]/Profile::Linux::Nexus::Server/Nexus3_repository[foo-npm]/depth: depth changed '' to '0'
Notice: /Stage[main]/Profile::Linux::Nexus::Server/Nexus3_repository[nuget-gallery]/depth: depth changed '' to '0'
```

Puppet sees an empty string `''` from the API, but wants to set a `0` - as `0` is the default `depth` value.

As setting a `depth` of `0` is valid for all repos regardless of whether `depth` is needed, the change in this PR will turn an empty `depth` string from an API read using the `Nexus3_repository` resource into a `0` so that Puppet does not think it needs to change any value.

This has benefits of keeping puppet runs clean.