### PR TITLE
Configure export databases for backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ nexus3_task { 'Empty Trash':
                                              # `repository.maven.rebuild-metadata`, `repository.maven.remove-snapshots`, 
                                              # `repository.maven.unpublish-dotindex`, `repository.purge-unused`, 
                                              # `repository.rebuild-index`, `script`, `security.purge-api-keys`, 
+                                             # `db.backup`,
   alert_email     => 'ops@example.com',      # optional; use `absent` (default) to disable the email notification
   frequency       => 'daily',                # one of `manual` (default), `once`, `daily`, `weekly`, `monthly` or `advanced`
   start_date      => '2014-05-31',

--- a/lib/puppet_x/nexus3/task.rb
+++ b/lib/puppet_x/nexus3/task.rb
@@ -17,6 +17,7 @@ module Nexus3
       'repository.rebuild-index' => [Nexus3::TaskField.new('repository_name')],
       'script' => [Nexus3::TaskField.new('language'), Nexus3::TaskField.new('source')],
       'security.purge-api-keys' => [],
+      'db.backup' => [Nexus3::TaskField.new('location')],
     }
 
     def self.frequency_to_schedule(resource)

--- a/spec/unit/puppet/provider/nexus3_task/ruby_spec.rb
+++ b/spec/unit/puppet/provider/nexus3_task/ruby_spec.rb
@@ -503,7 +503,7 @@ describe type_class.provider(:ruby) do
         script = <<~EOS
           def taskScheduler = container.lookup(org.sonatype.nexus.scheduling.TaskScheduler.class.name)
           def config = taskScheduler.createTaskConfigurationInstance('db.backup')
-          config.setName('example db backup')
+          config.setName('example')
           config.setEnabled(true)
           config.setAlertEmail('foo@server.com')
           config.setString('location', 'location')


### PR DESCRIPTION
Added `Admin - Export databases for backup` as a configurable task.

Example usage for performing a nightly backup of OrientDB and storing the output

```
nexus3_task { 'Run OrientDB backup':
  enabled         => true,
  type            => 'db.backup',
  alert_email     => 'ops@example.com',
  frequency       => 'daily',
  start_date      => '2018-11-29',
  start_time      => '03:00',
  location        => /mnt/nexus/backups/orientdb
}
```