### PR TITLE
Changes for issue #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,10 @@ nexus3_repository { 'new-repository':
   write_policy                   => 'allow_write_once',   #valid values: 'read_only', 'allow_write_once (default for maven2)', 'allow_write'
   strict_content_type_validation => true,                 #valid values: true (default), false
 
-  #the following 'remote_' properties may only be used when type => 'proxy'
+  #the following 'remote_' and '*block*' properties may only be used when type => 'proxy'
 
+  auto_block                     => false,                #optional, default is true
+  blocked                        => false,                #optional, default is false
   remote_url                     => 'http://some-repo/',  #required
   remote_auth_type               => 'none',               #valid values: 'none' (default), 'username' (default for maven2), 'ntlm'
   remote_user                    => 'some_user',          #optional, default is unspecified

--- a/lib/puppet/provider/nexus3_repository/templates/create_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/create_config.erb
@@ -11,10 +11,10 @@ storage.set('writePolicy', '<%= WRITE_POLICY_MAPPING[resource[:write_policy]] %>
 def proxy = config.attributes('proxy')
 proxy.set('remoteUrl', '<%= resource[:remote_url] %>')
 <%- end -%>
-<%- if resource[:remote_auth_type] == :none -%>
-config.getAttributes().remove('httpclient')
-<%- else -%>
 def httpclient = config.attributes('httpclient');
+<%- if resource[:remote_auth_type] == :none -%>
+httpclient.remove('authentication')
+<%- else -%>
 def authentication = httpclient.child('authentication');
 authentication.set('type', '<%= resource[:remote_auth_type] %>');
 authentication.set('username', '<%= resource[:remote_user] %>');

--- a/lib/puppet/provider/nexus3_repository/templates/create_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/create_config.erb
@@ -10,8 +10,9 @@ storage.set('writePolicy', '<%= WRITE_POLICY_MAPPING[resource[:write_policy]] %>
 <%- elsif resource[:type] == :proxy -%>
 def proxy = config.attributes('proxy')
 proxy.set('remoteUrl', '<%= resource[:remote_url] %>')
-<%- end -%>
 def httpclient = config.attributes('httpclient');
+httpclient.set('blocked', '<%= resource[:blocked] %>');
+httpclient.set('autoBlock', '<%= resource[:auto_block] %>');
 <%- if resource[:remote_auth_type] == :none -%>
 httpclient.remove('authentication')
 <%- else -%>
@@ -21,6 +22,7 @@ authentication.set('username', '<%= resource[:remote_user] %>');
 authentication.set('password', '<%= resource[:remote_password] %>');
 authentication.set('ntlmHost', '<%= resource[:remote_ntlm_host] %>');
 authentication.set('ntlmDomain', '<%= resource[:remote_ntlm_domain] %>');
+<%- end -%>
 <%- end -%>
 <%- if resource[:provider_type] == :apt -%>
 def apt = config.attributes('apt')

--- a/lib/puppet/provider/nexus3_repository/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/read_config.erb
@@ -30,6 +30,8 @@ def infos = repositories.findResults { repository ->
     remote_url: proxy.get('remoteUrl'),
     version_policy: maven.get('versionPolicy')?.toLowerCase(),
     layout_policy: maven.get('layoutPolicy')?.toLowerCase(),
+    auto_block: httpclient.get('autoBlock'),
+    blocked: httpclient.get('blocked'),
     remote_auth_type: authentication.get('type') ? authentication.get('type') : 'none',
     remote_user: authentication.get('username'),
     remote_password: authentication.get('password'),

--- a/lib/puppet/provider/nexus3_repository/templates/write_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/write_config.erb
@@ -7,8 +7,9 @@ storage.set('writePolicy', '<%= WRITE_POLICY_MAPPING[resource[:write_policy]] %>
 <%- elsif resource[:type] == :proxy -%>
 def proxy = config.attributes('proxy')
 proxy.set('remoteUrl', '<%= resource[:remote_url] %>')
-<%- end -%>
 def httpclient = config.attributes('httpclient');
+httpclient.set('blocked', '<%= resource[:blocked] %>');
+httpclient.set('autoBlock', '<%= resource[:auto_block] %>');
 <%- if resource[:remote_auth_type] == :none -%>
 httpclient.remove('authentication')
 <%- else -%>
@@ -18,6 +19,7 @@ authentication.set('username', '<%= resource[:remote_user] %>');
 authentication.set('password', '<%= resource[:remote_password] %>');
 authentication.set('ntlmHost', '<%= resource[:remote_ntlm_host] %>');
 authentication.set('ntlmDomain', '<%= resource[:remote_ntlm_domain] %>');
+<%- end -%>
 <%- end -%>
 <%- if resource[:provider_type] == :apt -%>
 def apt = config.attributes('apt')

--- a/lib/puppet/provider/nexus3_repository/templates/write_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/write_config.erb
@@ -8,10 +8,10 @@ storage.set('writePolicy', '<%= WRITE_POLICY_MAPPING[resource[:write_policy]] %>
 def proxy = config.attributes('proxy')
 proxy.set('remoteUrl', '<%= resource[:remote_url] %>')
 <%- end -%>
-<%- if resource[:remote_auth_type] == :none -%>
-config.getAttributes().remove('httpclient')
-<%- else -%>
 def httpclient = config.attributes('httpclient');
+<%- if resource[:remote_auth_type] == :none -%>
+httpclient.remove('authentication')
+<%- else -%>
 def authentication = httpclient.child('authentication');
 authentication.set('type', '<%= resource[:remote_auth_type] %>');
 authentication.set('username', '<%= resource[:remote_user] %>');

--- a/lib/puppet/type/nexus3_repository.rb
+++ b/lib/puppet/type/nexus3_repository.rb
@@ -125,6 +125,22 @@ Puppet::Type.newtype(:nexus3_repository) do
   end
 
   # proxy-specific #
+  newproperty(:auto_block, parent: Puppet::Property::Boolean) do
+    desc 'Whether to automatically block outbound connections to remote repository in case of unresponsiveness.' \
+         'Only useful for proxy-type repositories.'
+    newvalues(:true, :false)
+    defaultto do @resource[:type] == :proxy ? :true : nil end
+    munge { |value| super(value).to_s.intern }
+  end
+
+  newproperty(:blocked, parent: Puppet::Property::Boolean) do
+    desc 'Whether to block connection to remote repository.' \
+         'Only useful for proxy-type repositories.'
+    newvalues(:true, :false)
+    defaultto do @resource[:type] == :proxy ? :false : nil end
+    munge { |value| super(value).to_s.intern }
+  end
+
   newproperty(:remote_url) do
     desc 'This is the location of the remote repository being proxied. Only HTTP/HTTPs urls are currently supported. ' \
          'Only useful for proxy-type repositories.'

--- a/spec/unit/puppet/provider/nexus3_repository/ruby_spec.rb
+++ b/spec/unit/puppet/provider/nexus3_repository/ruby_spec.rb
@@ -123,6 +123,8 @@ describe type_class.provider(:ruby) do
             remote_url: proxy.get('remoteUrl'),
             version_policy: maven.get('versionPolicy')?.toLowerCase(),
             layout_policy: maven.get('layoutPolicy')?.toLowerCase(),
+            auto_block: httpclient.get('autoBlock'),
+            blocked: httpclient.get('blocked'),
             remote_auth_type: authentication.get('type') ? authentication.get('type') : 'none',
             remote_user: authentication.get('username'),
             remote_password: authentication.get('password'),
@@ -216,6 +218,8 @@ describe type_class.provider(:ruby) do
         def proxy = config.attributes('proxy')
         proxy.set('remoteUrl', 'http://remote.server.com')
         def httpclient = config.attributes('httpclient');
+        httpclient.set('blocked', 'false');
+        httpclient.set('autoBlock', 'true');
         def authentication = httpclient.child('authentication');
         authentication.set('type', 'ntlm');
         authentication.set('username', 'user');
@@ -243,13 +247,6 @@ describe type_class.provider(:ruby) do
           storage.set('blobStoreName', 'blob_store')
           storage.set('strictContentTypeValidation', false)
           storage.set('writePolicy', 'ALLOW')
-          def httpclient = config.attributes('httpclient');
-          def authentication = httpclient.child('authentication');
-          authentication.set('type', 'ntlm');
-          authentication.set('username', 'user');
-          authentication.set('password', 'pass');
-          authentication.set('ntlmHost', 'ntlmhost');
-          authentication.set('ntlmDomain', 'ntlmdomain');
           repository.repositoryManager.create(config)
         EOS
         expect(Nexus3::API).to receive(:execute_script).with(script)
@@ -274,6 +271,8 @@ describe type_class.provider(:ruby) do
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
           def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
           def authentication = httpclient.child('authentication');
           authentication.set('type', 'ntlm');
           authentication.set('username', 'user');
@@ -307,6 +306,8 @@ describe type_class.provider(:ruby) do
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
           def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
           def authentication = httpclient.child('authentication');
           authentication.set('type', 'ntlm');
           authentication.set('username', 'user');
@@ -340,6 +341,8 @@ describe type_class.provider(:ruby) do
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
           def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
           def authentication = httpclient.child('authentication');
           authentication.set('type', 'ntlm');
           authentication.set('username', 'user');
@@ -370,13 +373,6 @@ describe type_class.provider(:ruby) do
           storage.set('blobStoreName', 'blob_store')
           storage.set('strictContentTypeValidation', false)
           storage.set('writePolicy', 'ALLOW')
-          def httpclient = config.attributes('httpclient');
-          def authentication = httpclient.child('authentication');
-          authentication.set('type', 'ntlm');
-          authentication.set('username', 'user');
-          authentication.set('password', 'pass');
-          authentication.set('ntlmHost', 'ntlmhost');
-          authentication.set('ntlmDomain', 'ntlmdomain');
           def docker = config.attributes('docker')
           docker.set('httpPort', '8442')
           docker.set('httpsPort', '8443')
@@ -406,6 +402,8 @@ describe type_class.provider(:ruby) do
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
           def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
           def authentication = httpclient.child('authentication');
           authentication.set('type', 'ntlm');
           authentication.set('username', 'user');
@@ -443,7 +441,10 @@ describe type_class.provider(:ruby) do
           storage.set('strictContentTypeValidation', false)
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
-          config.getAttributes().remove('httpclient')
+          def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
+          httpclient.remove('authentication')
           repository.repositoryManager.create(config)
         EOS
         expect(Nexus3::API).to receive(:execute_script).with(script)
@@ -467,6 +468,8 @@ describe type_class.provider(:ruby) do
         def proxy = config.attributes('proxy')
         proxy.set('remoteUrl', 'http://remote.server.com')
         def httpclient = config.attributes('httpclient');
+        httpclient.set('blocked', 'false');
+        httpclient.set('autoBlock', 'true');
         def authentication = httpclient.child('authentication');
         authentication.set('type', 'ntlm');
         authentication.set('username', 'user');
@@ -492,13 +495,6 @@ describe type_class.provider(:ruby) do
           def storage = config.attributes('storage')
           storage.set('strictContentTypeValidation', false)
           storage.set('writePolicy', 'ALLOW')
-          def httpclient = config.attributes('httpclient');
-          def authentication = httpclient.child('authentication');
-          authentication.set('type', 'ntlm');
-          authentication.set('username', 'user');
-          authentication.set('password', 'pass');
-          authentication.set('ntlmHost', 'ntlmhost');
-          authentication.set('ntlmDomain', 'ntlmdomain');
           repository.repositoryManager.update(config)
         EOS
         expect(Nexus3::API).to receive(:execute_script).with(script)
@@ -521,6 +517,8 @@ describe type_class.provider(:ruby) do
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
           def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
           def authentication = httpclient.child('authentication');
           authentication.set('type', 'ntlm');
           authentication.set('username', 'user');
@@ -552,6 +550,8 @@ describe type_class.provider(:ruby) do
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
           def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
           def authentication = httpclient.child('authentication');
           authentication.set('type', 'ntlm');
           authentication.set('username', 'user');
@@ -583,6 +583,8 @@ describe type_class.provider(:ruby) do
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
           def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
           def authentication = httpclient.child('authentication');
           authentication.set('type', 'ntlm');
           authentication.set('username', 'user');
@@ -612,7 +614,10 @@ describe type_class.provider(:ruby) do
           storage.set('strictContentTypeValidation', false)
           def proxy = config.attributes('proxy')
           proxy.set('remoteUrl', 'http://remote.server.com')
-          config.getAttributes().remove('httpclient')
+          def httpclient = config.attributes('httpclient');
+          httpclient.set('blocked', 'false');
+          httpclient.set('autoBlock', 'true');
+          httpclient.remove('authentication')
           repository.repositoryManager.update(config)
         EOS
         expect(Nexus3::API).to receive(:execute_script).with(script)

--- a/spec/unit/puppet/type/nexus3_repository_spec.rb
+++ b/spec/unit/puppet/type/nexus3_repository_spec.rb
@@ -20,6 +20,8 @@ describe Puppet::Type.type(:nexus3_repository) do
     it { expect(instance[:version_policy]).to eq nil }
     it { expect(instance[:layout_policy]).to eq nil }
     it { expect(instance[:write_policy]).to eq nil }
+    it { expect(instance[:auto_block]).to eq(:true) }
+    it { expect(instance[:blocked]).to eq(:false) }
     it { expect(instance[:remote_url]).to eq nil }
     it { expect(instance[:remote_auth_type]).to eq(:none) }
     it { expect(instance[:remote_user]).to eq nil }
@@ -83,7 +85,7 @@ describe Puppet::Type.type(:nexus3_repository) do
   end
 
   describe :online do
-    specify 'should default to false' do
+    specify 'should default to true' do
       expect(subject.new(required_values)[:online]).to be :true
     end
 
@@ -92,7 +94,7 @@ describe Puppet::Type.type(:nexus3_repository) do
       expect(subject.new(required_values.merge(online: :true))[:online]).to be :true
     end
 
-    specify 'should accept "true' do
+    specify 'should accept "true"' do
       expect { subject.new(required_values.merge(online: 'true')) }.to_not raise_error
       expect(subject.new(required_values.merge(online: 'true'))[:online]).to be :true
     end
@@ -105,6 +107,32 @@ describe Puppet::Type.type(:nexus3_repository) do
     specify 'should accept "false"' do
       expect { subject.new(required_values.merge(online: 'false')) }.to_not raise_error
       expect(subject.new(required_values.merge(online: 'false'))[:online]).to be :false
+    end
+  end
+
+  describe :blocked do
+    specify 'should default to false' do
+      expect(subject.new(required_values)[:blocked]).to be :false
+    end
+
+    specify 'should accept :true' do
+      expect { subject.new(required_values.merge(blocked: :true)) }.to_not raise_error
+      expect(subject.new(required_values.merge(blocked: :true))[:blocked]).to be :true
+    end
+
+    specify 'should accept "true"' do
+      expect { subject.new(required_values.merge(blocked: 'true')) }.to_not raise_error
+      expect(subject.new(required_values.merge(blocked: 'true'))[:blocked]).to be :true
+    end
+
+    specify 'should accept :false' do
+      expect { subject.new(required_values.merge(blocked: :false)) }.to_not raise_error
+      expect(subject.new(required_values.merge(blocked: :false))[:blocked]).to be :false
+    end
+
+    specify 'should accept "false"' do
+      expect { subject.new(required_values.merge(blocked: 'false')) }.to_not raise_error
+      expect(subject.new(required_values.merge(blocked: 'false'))[:blocked]).to be :false
     end
   end
 


### PR DESCRIPTION
This fixes the HTTP -> Authentication is always checked problem and adds support for managing the `blocked` and `autoBlock` attributes. Change has been tested to work for proxy repositories. It has also been verified that both changes don't affect hosted repositories in any way.