### PR TITLE
Add type/provider for managing cleanup policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,22 @@ nexus3_blobstore { 'docker':
 }
 ```
 
+### Cleanup Policies ###
+
+Cleanup policies can be set up using the `nexus3_cleanup_policy` resource:
+
+```
+#!puppet
+nexus3_cleanup_policy { 'new_cleanup_policy':
+  format            => 'apt',               #Repository format this policy applies to. Valid values: 'all', 'apt', 'bower', 'docker', 'gitlfs' (hosted), 'maven2', 'npm', 'nuget', 'pypi', 'raw', 'rubygems', 'yum'
+  notes             => 'Short description', #Optional: default is ''
+  is_prerelease     => true,                #Whether the policy should apply to "release" or "prerelease" type repos. Valid values: true, false (default). Only applies to 'maven2', 'npm' or 'yum' repos
+  last_blob_updated => 7,                   #Whether the policy should consider time (in days) of a components last update
+  last_downloaded   => 14,                  #Whether the policy should consider time (in days) of a components last download
+  regex             => '.*all\.deb',        #Match component name by this regular expression (not available if format is 'all', 'gitlfs' or 'yum')
+}
+```
+
 ### Repository Configuration ###
 
 The Nexus Repository settings can be configured using the `nexus3_repository` and `nexus3_repository_group` resources:
@@ -265,9 +281,13 @@ The Nexus Repository settings can be configured using the `nexus3_repository` an
 #!puppet
 nexus3_repository { 'new-repository':
   type                           => 'hosted',             #valid values: 'hosted', 'proxy'
-  provider_type                  => 'maven2',             #valid values: 'bower', 'docker', 'gitlfs' (hosted), 'maven2', 'npm', 'nuget', 'pypi', 'raw', 'rubygems', 'yum'
+  provider_type                  => 'maven2',             #valid values: 'apt', 'bower', 'docker', 'gitlfs' (hosted), 'maven2', 'npm', 'nuget', 'pypi', 'raw', 'rubygems', 'yum'
   online                         => false,                #valid values: true (default), false
   blobstore_name                 => 'blob',               #optional, default is 'default'
+  cleanup_policies               => [                     #names of existing cleanup policies
+                                      'policy1',
+                                      'policy2',
+                                    ],
   version_policy                 => 'snapshot',           #valid values: 'snapshot', 'release' (default for maven2), 'mixed'
   write_policy                   => 'allow_write_once',   #valid values: 'read_only', 'allow_write_once (default for maven2)', 'allow_write'
   strict_content_type_validation => true,                 #valid values: true (default), false
@@ -383,6 +403,7 @@ and
 Furthermore, the module has been tested with the following Nexus versions:
 
 * Nexus OSS 3.1.0-04+ running on Ubuntu 16.04
+* Nexus OSS 3.19.1-01 running on Ubuntu 18.04 (for the cleanup policy stuff)
 
 ### A note on passwords ###
 

--- a/lib/puppet/provider/nexus3_cleanup_policy/ruby.rb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/ruby.rb
@@ -1,0 +1,12 @@
+require 'erb'
+require File.join(File.dirname(__FILE__), '..', 'nexus3_base')
+
+Puppet::Type.type(:nexus3_cleanup_policy).provide(:ruby, parent: Puppet::Provider::Nexus3Base) do
+  desc 'Ruby-based management of Nexus 3 Cleanup Policy.'
+
+  def self.templates_folder
+    File.join(File.dirname(__FILE__), 'templates')
+  end
+
+  mk_resource_methods
+end

--- a/lib/puppet/provider/nexus3_cleanup_policy/templates/create_config.erb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/templates/create_config.erb
@@ -2,21 +2,21 @@ def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupP
 
 def criteria = [:]
 <%- unless resource[:is_prerelease].nil? -%>
-criteria.isPrerelease = <%= resource[:is_prerelease] =>
+criteria.isPrerelease = <%= resource[:is_prerelease] %>
 <%- end -%>
 <%- unless resource[:last_blob_updated].nil? -%>
-criteria.lastBlobUpdated = <%= resource[:last_blob_updated] * 60 * 60 * 24 =>
+criteria.lastBlobUpdated = <%= resource[:last_blob_updated] * 60 * 60 * 24 %>.toString()
 <%- end -%>
 <%- unless resource[:last_downloaded].nil? -%>
-criteria.lastDownloaded = <%= resource[:last_downloaded] * 60 * 60 * 24 =>
+criteria.lastDownloaded = <%= resource[:last_downloaded] * 60 * 60 * 24 %>.toString()
 <%- end -%>
 <%- unless resource[:regex].nil? -%>
-criteria.regex = <%= resource[:regex] =>
+criteria.regex = <%= resource[:regex] %>
 <%- end -%>
 
-def policy = org.sonatype.nexus.cleanup.storage.CleanupPolicy.new()
+def policy = new org.sonatype.nexus.cleanup.storage.CleanupPolicy()
 policy.setCriteria(criteria)
-policy.setFormat('<%= resource[:format] %>')
+policy.setFormat(('<%= resource[:format] %>' == 'all' ? 'ALL_FORMATS' : '<%= resource[:format] %>'))
 policy.setName('<%= resource[:name] %>')
 policy.setNotes('<%= resource[:notes] %>')
 policy.setMode('delete')

--- a/lib/puppet/provider/nexus3_cleanup_policy/templates/create_config.erb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/templates/create_config.erb
@@ -1,0 +1,24 @@
+def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+
+def criteria = [:]
+<%- unless resource[:is_prerelease].nil? -%>
+criteria.isPrerelease = <%= resource[:is_prerelease] =>
+<%- end -%>
+<%- unless resource[:last_blob_updated].nil? -%>
+criteria.lastBlobUpdated = <%= resource[:last_blob_updated] * 60 * 60 * 24 =>
+<%- end -%>
+<%- unless resource[:last_downloaded].nil? -%>
+criteria.lastDownloaded = <%= resource[:last_downloaded] * 60 * 60 * 24 =>
+<%- end -%>
+<%- unless resource[:regex].nil? -%>
+criteria.regex = <%= resource[:regex] =>
+<%- end -%>
+
+def policy = org.sonatype.nexus.cleanup.storage.CleanupPolicy.new()
+policy.setCriteria(criteria)
+policy.setFormat('<%= resource[:format] %>')
+policy.setName('<%= resource[:name] %>')
+policy.setNotes('<%= resource[:notes] %>')
+policy.setMode('delete')
+
+policyStorage.add(policy)

--- a/lib/puppet/provider/nexus3_cleanup_policy/templates/delete_config.erb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/templates/delete_config.erb
@@ -1,0 +1,4 @@
+def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+if (policyStorage.exists('<%= resource[:name] %>')) {
+  policyStorage.remove(policyStorage.get('<%= resource[:name] %>'))
+}

--- a/lib/puppet/provider/nexus3_cleanup_policy/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/templates/read_config.erb
@@ -1,0 +1,20 @@
+def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+def policies = policyStorage.getAll()
+
+def infos = []
+policies.each { policy ->
+  def attributes = [
+    name: policy.getName(),
+    notes: policy.getNotes(),
+    format: policy.getFormat(),
+  ]
+  def criteria = policy.getCriteria()
+  attributes.regex = (criteria.containsKey('regex') ? criteria['regex'] : null)
+  attributes.last_downloaded = (criteria.containsKey('lastDownloaded') ? criteria['lastDownloaded'].toInteger() / 60 / 60 / 24 : null)
+  attributes.last_blob_updated = (criteria.containsKey('lastBlobUpdated') ? criteria['lastBlobUpdated'].toInteger() / 60 / 60 / 24 : null)
+  attributes.is_prerelease = (criteria.containsKey('isPrerelease') ? criteria['isPrerelease'].toBoolean() : null)
+
+  infos << attributes
+}
+
+return groovy.json.JsonOutput.toJson(infos)

--- a/lib/puppet/provider/nexus3_cleanup_policy/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/templates/read_config.erb
@@ -6,8 +6,10 @@ policies.each { policy ->
   def attributes = [
     name: policy.getName(),
     notes: policy.getNotes(),
-    format: policy.getFormat(),
   ]
+  def format = policy.getFormat()
+  attributes.format = (format == 'ALL_FORMATS' ? 'all' : format)
+
   def criteria = policy.getCriteria()
   attributes.regex = (criteria.containsKey('regex') ? criteria['regex'] : null)
   attributes.last_downloaded = (criteria.containsKey('lastDownloaded') ? criteria['lastDownloaded'].toInteger() / 60 / 60 / 24 : null)

--- a/lib/puppet/provider/nexus3_cleanup_policy/templates/write_config.erb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/templates/write_config.erb
@@ -1,0 +1,23 @@
+def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+
+def criteria = [:]
+<%- unless resource[:is_prerelease].nil? -%>
+criteria.isPrerelease = <%= resource[:is_prerelease] =>
+<%- end -%>
+<%- unless resource[:last_blob_updated].nil? -%>
+criteria.lastBlobUpdated = <%= resource[:last_blob_updated] * 60 * 60 * 24 =>
+<%- end -%>
+<%- unless resource[:last_downloaded].nil? -%>
+criteria.lastDownloaded = <%= resource[:last_downloaded] * 60 * 60 * 24 =>
+<%- end -%>
+<%- unless resource[:regex].nil? -%>
+criteria.regex = <%= resource[:regex] =>
+<%- end -%>
+
+def policy = policyStorage.get('<%= resource[:name] %>')
+policy.setCriteria(criteria)
+policy.setFormat('<%= resource[:format] %>')
+policy.setNotes('<%= resource[:notes] %>')
+policy.setMode('delete')
+
+policyStorage.update(policy)

--- a/lib/puppet/provider/nexus3_cleanup_policy/templates/write_config.erb
+++ b/lib/puppet/provider/nexus3_cleanup_policy/templates/write_config.erb
@@ -2,21 +2,21 @@ def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupP
 
 def criteria = [:]
 <%- unless resource[:is_prerelease].nil? -%>
-criteria.isPrerelease = <%= resource[:is_prerelease] =>
+criteria.isPrerelease = <%= resource[:is_prerelease] %>
 <%- end -%>
 <%- unless resource[:last_blob_updated].nil? -%>
-criteria.lastBlobUpdated = <%= resource[:last_blob_updated] * 60 * 60 * 24 =>
+criteria.lastBlobUpdated = <%= resource[:last_blob_updated] * 60 * 60 * 24 %>.toString()
 <%- end -%>
 <%- unless resource[:last_downloaded].nil? -%>
-criteria.lastDownloaded = <%= resource[:last_downloaded] * 60 * 60 * 24 =>
+criteria.lastDownloaded = <%= resource[:last_downloaded] * 60 * 60 * 24 %>.toString()
 <%- end -%>
 <%- unless resource[:regex].nil? -%>
-criteria.regex = <%= resource[:regex] =>
+criteria.regex = <%= resource[:regex] %>
 <%- end -%>
 
 def policy = policyStorage.get('<%= resource[:name] %>')
 policy.setCriteria(criteria)
-policy.setFormat('<%= resource[:format] %>')
+policy.setFormat(('<%= resource[:format] %>' == 'all' ? 'ALL_FORMATS' : '<%= resource[:format] %>'))
 policy.setNotes('<%= resource[:notes] %>')
 policy.setMode('delete')
 

--- a/lib/puppet/provider/nexus3_repository/templates/create_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/create_config.erb
@@ -22,6 +22,16 @@ authentication.set('password', '<%= resource[:remote_password] %>');
 authentication.set('ntlmHost', '<%= resource[:remote_ntlm_host] %>');
 authentication.set('ntlmDomain', '<%= resource[:remote_ntlm_domain] %>');
 <%- end -%>
+<%- unless resource[:cleanup_policies].nil? -%>
+// This is really strange: It requires a java.util.Set when writing the list
+// of cleanup policies, but returns a java.util.ArrayList when reading it
+Set policies = []
+def cleanup = config.attributes('cleanup')
+<%- resource[:cleanup_policies].each do |policy| -%>
+policies << '<%= policy %>'
+cleanup.set('policyName', policies)
+<%- end -%>
+<%- end -%>
 <%- if resource[:provider_type] == :apt -%>
 def apt = config.attributes('apt')
 apt.set('distribution', '<%= resource[:distribution] %>')

--- a/lib/puppet/provider/nexus3_repository/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/read_config.erb
@@ -7,12 +7,13 @@ def infos = repositories.findResults { repository ->
     return null
   }
 
+  def cleanup = config.attributes('cleanup')
   def storage = config.attributes('storage')
   def proxy = config.attributes('proxy')
   def group = config.attributes('group')
   def maven = config.attributes('maven')
   def yum   = config.attributes('yum')
-  def docker= config.attributes('docker')
+  def docker = config.attributes('docker')
   def dockerProxy = config.attributes('dockerProxy')
   def apt = config.attributes('apt')
   def aptSigning = config.attributes('aptSigning')
@@ -24,6 +25,7 @@ def infos = repositories.findResults { repository ->
     type: type,
     provider_type: providerType,
     online: config.isOnline(),
+    cleanup_policies: cleanup.get('policyName'),
     write_policy: storage.get('writePolicy'),
     blobstore_name: storage.get('blobStoreName'),
     strict_content_type_validation: storage.get('strictContentTypeValidation'),

--- a/lib/puppet/provider/nexus3_repository/templates/write_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/write_config.erb
@@ -19,6 +19,16 @@ authentication.set('password', '<%= resource[:remote_password] %>');
 authentication.set('ntlmHost', '<%= resource[:remote_ntlm_host] %>');
 authentication.set('ntlmDomain', '<%= resource[:remote_ntlm_domain] %>');
 <%- end -%>
+<%- unless resource[:cleanup_policies].nil? -%>
+// This is really strange: It requires a java.util.Set when writing the list
+// of cleanup policies, but returns a java.util.ArrayList when reading it
+Set policies = []
+def cleanup = config.attributes('cleanup')
+<%- resource[:cleanup_policies].each do |policy| -%>
+policies << '<%= policy %>'
+cleanup.set('policyName', policies)
+<%- end -%>
+<%- end -%>
 <%- if resource[:provider_type] == :apt -%>
 def apt = config.attributes('apt')
 apt.set('distribution', '<%= resource[:distribution] %>')

--- a/lib/puppet/type/nexus3_cleanup_policy.rb
+++ b/lib/puppet/type/nexus3_cleanup_policy.rb
@@ -24,7 +24,9 @@ Puppet::Type.newtype(:nexus3_cleanup_policy) do
     desc 'Restrict cleanup to components of release type "release" or "prerelease".' \
          'This is applicable to "maven2", "npm", or "yum" format repos only.'
     newvalues(:true, :false)
-    defaultto do [:maven2, :npm, :yum].include?(@resource[:format]) ? :false : nil end
+    defaultto do
+      :false if [:maven2, :npm, :yum].include?(@resource[:format])
+    end
     munge { |value| super(value).to_s.intern }
   end
 

--- a/lib/puppet/type/nexus3_cleanup_policy.rb
+++ b/lib/puppet/type/nexus3_cleanup_policy.rb
@@ -24,7 +24,7 @@ Puppet::Type.newtype(:nexus3_cleanup_policy) do
     desc 'Restrict cleanup to components of release type "release" or "prerelease".' \
          'This is applicable to "maven2", "npm", or "yum" format repos only.'
     newvalues(:true, :false)
-    defaultto do @resource[:format] in [:maven2, :npm, :yum] ? :false : nil end
+    defaultto do [:maven2, :npm, :yum].include?(@resource[:format]) ? :false : nil end
     munge { |value| super(value).to_s.intern }
   end
 

--- a/lib/puppet/type/nexus3_cleanup_policy.rb
+++ b/lib/puppet/type/nexus3_cleanup_policy.rb
@@ -1,0 +1,57 @@
+require 'puppet/property/boolean'
+
+Puppet::Type.newtype(:nexus3_cleanup_policy) do
+  @doc = 'Manages Nexus 3 Cleanup Policy'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'Unique cleanup policy name.'
+  end
+
+  newproperty(:format) do
+    desc 'The repository format the policy should apply to (can also be "all").'
+    newvalues(:all, :apt, :bower, :composer, :docker, :gitlfs, :maven2, :npm, :nuget, :pypi, :raw, :rubygems, :yum)
+    defaultto :all
+  end
+
+  newproperty(:notes) do
+    desc 'A short description of the policy.'
+    defaultto ''
+  end
+
+  newproperty(:is_prerelease, parent: Puppet::Property::Boolean) do
+    desc 'Restrict cleanup to components of release type "release" or "prerelease".' \
+         'This is applicable to "maven2", "npm", or "yum" format repos only.'
+    newvalues(:true, :false)
+    defaultto do @resource[:format] in [:maven2, :npm, :yum] ? :false : nil end
+    munge { |value| super(value).to_s.intern }
+  end
+
+  newproperty(:last_blob_updated) do
+    desc 'Restrict cleanup to components last updated before this number of days.'
+    munge { |value| Integer(value) }
+  end
+
+  newproperty(:last_downloaded) do
+    desc 'Restrict cleanup to components last downloaded before this number of days.'
+    munge { |value| Integer(value) }
+  end
+
+  newproperty(:regex) do
+    desc 'Restrict cleanup to components whose names match this regular expression.'
+  end
+
+  validate do
+    if self[:ensure] == :present
+      raise ArgumentError, 'At least one criteria must be provided' if self[:is_prerelease].nil? &&
+                                                                       self[:last_blob_updated].nil? &&
+                                                                       self[:last_downloaded].nil? &&
+                                                                       self[:regex].nil?
+    end
+  end
+
+  autorequire(:file) do
+    Nexus3::Config::file_path
+  end
+end

--- a/lib/puppet/type/nexus3_repository.rb
+++ b/lib/puppet/type/nexus3_repository.rb
@@ -31,6 +31,13 @@ Puppet::Type.newtype(:nexus3_repository) do
     defaultto 'default'
   end
 
+  newproperty(:cleanup_policies, array_matching: :all) do
+    desc 'A list of cleanup policies to apply to this repository'
+    validate do |value|
+      raise ArgumentError, 'cleanup policies must be provided as array' if value.empty? || value.include?(',')
+    end
+  end
+
   newproperty(:version_policy) do
     desc 'Maven2 repositories can store release, snapshot or mixed artifacts.'
     defaultto do @resource[:provider_type] == :maven2 ? :release : nil end

--- a/spec/unit/puppet/provider/nexus3_cleanup_policy/ruby_spec.rb
+++ b/spec/unit/puppet/provider/nexus3_cleanup_policy/ruby_spec.rb
@@ -1,0 +1,194 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:nexus3_cleanup_policy)
+
+describe type_class.provider(:ruby) do
+  before(:each) { stub_default_config_and_healthcheck }
+
+  let(:values) do
+    {
+      last_downloaded: 30,
+    }
+  end
+
+  let(:resource_extra_attributes) do
+    {}
+  end
+
+  let(:instance) do
+    resource = type_class.new(values.merge(name: 'example').merge(resource_extra_attributes))
+    instance = described_class.new(values.merge(name: 'example').merge(resource_extra_attributes))
+    resource.provider = instance
+    instance
+  end
+
+  describe 'define getters and setters to some type properties or params' do
+    let(:instance) { described_class.new }
+
+    [:format, :last_downloaded].each do |method|
+      specify { expect(instance.respond_to?(method)).to be_truthy }
+      specify { expect(instance.respond_to?("#{method}=")).to be_truthy }
+    end
+  end
+
+  describe 'prefetch' do
+    it 'should not raise error if more than one resource of this type is configured' do
+      allow(Nexus3::API).to receive(:execute_script).and_return('[]')
+
+      expect {
+        described_class.prefetch({example1: type_class.new(values.merge(name: 'example1')), example2: type_class.new(values.merge(name: 'example2'))})
+      }.not_to raise_error
+    end
+
+    describe 'found instance' do
+      before(:each) { allow(Nexus3::API).to receive(:execute_script).and_return([{name: 'example1', format: 'all'}].to_json) }
+
+      it 'should not set the format' do
+        resources = {example1: type_class.new(values.merge(name: 'example1'))}
+        described_class.prefetch(resources)
+        expect(resources[:example1].provider.notes).to eq('')
+        expect(resources[:example1][:notes]).to be_truthy
+      end
+    end
+
+    describe 'not found instance' do
+      before(:each) { allow(Nexus3::API).to receive(:execute_script).and_return('[]') }
+
+      it 'should not set the format' do
+        resources = {example1: type_class.new(values.merge(name: 'example1'))}
+        described_class.prefetch(resources)
+        expect(resources[:example1].provider.notes).to eq(:absent)
+        expect(resources[:example1][:notes]).to be_truthy
+      end
+    end
+  end
+
+  describe 'instances' do
+    specify 'should execute a script to get repositories settings' do
+      script = <<~EOS
+        def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+        def policies = policyStorage.getAll()
+
+        def infos = []
+        policies.each { policy ->
+          def attributes = [
+            name: policy.getName(),
+            notes: policy.getNotes(),
+          ]
+          def format = policy.getFormat()
+          attributes.format = (format == 'ALL_FORMATS' ? 'all' : format)
+
+          def criteria = policy.getCriteria()
+          attributes.regex = (criteria.containsKey('regex') ? criteria['regex'] : null)
+          attributes.last_downloaded = (criteria.containsKey('lastDownloaded') ? criteria['lastDownloaded'].toInteger() / 60 / 60 / 24 : null)
+          attributes.last_blob_updated = (criteria.containsKey('lastBlobUpdated') ? criteria['lastBlobUpdated'].toInteger() / 60 / 60 / 24 : null)
+          attributes.is_prerelease = (criteria.containsKey('isPrerelease') ? criteria['isPrerelease'].toBoolean() : null)
+
+          infos << attributes
+        }
+
+        return groovy.json.JsonOutput.toJson(infos)
+      EOS
+      expect(Nexus3::API).to receive(:execute_script).with(script).and_return('[{}]')
+      described_class.instances
+    end
+
+    specify 'should use default values to non set properties' do
+      allow(Nexus3::API).to receive(:execute_script).and_return('[{}]')
+      instances = described_class.instances
+      expect(instances.length).to eq 1
+      expect(instances[0].notes).to eq('')
+    end
+
+    specify 'should map each returned values to the correspondent property' do
+      allow(Nexus3::API).to receive(:execute_script).and_return([values].to_json)
+      instances = described_class.instances
+      expect(instances.length).to eq 1
+      expect(instances[0].last_downloaded).to eq(30)
+    end
+  end
+
+  describe 'create' do
+    it 'should execute a script to create the instance' do
+      script = <<~EOS
+        def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+
+        def criteria = [:]
+        criteria.lastDownloaded = 2592000.toString()
+
+        def policy = new org.sonatype.nexus.cleanup.storage.CleanupPolicy()
+        policy.setCriteria(criteria)
+        policy.setFormat(('all' == 'all' ? 'ALL_FORMATS' : 'all'))
+        policy.setName('example')
+        policy.setNotes('')
+        policy.setMode('delete')
+
+        policyStorage.add(policy)
+      EOS
+      expect(Nexus3::API).to receive(:execute_script).with(script).and_return('{}')
+      instance.create
+    end
+
+    it 'should raise a human readable error message if the operation failed' do
+      allow(Nexus3::API).to receive(:execute_script).and_raise('Operation failed')
+      expect { instance.create }.to raise_error(Puppet::Error, /Error while creating nexus3_cleanup_policy example/)
+    end
+  end
+
+  describe 'flush' do
+    it 'should execute a script to update the instance' do
+      script = <<~EOS
+        def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+
+        def criteria = [:]
+        criteria.lastDownloaded = 2592000.toString()
+
+        def policy = policyStorage.get('example')
+        policy.setCriteria(criteria)
+        policy.setFormat(('all' == 'all' ? 'ALL_FORMATS' : 'all'))
+        policy.setNotes('')
+        policy.setMode('delete')
+
+        policyStorage.update(policy)
+      EOS
+      expect(Nexus3::API).to receive(:execute_script).with(script).and_return('{}')
+      instance.mark_config_dirty
+      instance.flush
+    end
+
+    it 'should raise a human readable error message if the operation failed' do
+      allow(Nexus3::API).to receive(:execute_script).and_raise('Operation failed')
+      instance.mark_config_dirty
+      expect { instance.flush }.to raise_error(Puppet::Error, /Error while updating nexus3_cleanup_policy example/)
+    end
+
+    describe 'when some value has changed' do
+      before(:each) { instance.last_downloaded = 29 }
+
+      specify { expect(instance.instance_variable_get(:@update_required)).to be_truthy }
+    end
+  end
+
+  describe 'destroy' do
+    it 'should execute a script to destroy the instance' do
+      script = <<~EOS
+        def policyStorage = container.lookup(org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage.class.name)
+        if (policyStorage.exists('example')) {
+          policyStorage.remove(policyStorage.get('example'))
+        }
+      EOS
+      expect(Nexus3::API).to receive(:execute_script).with(script).and_return('{}')
+      instance.destroy
+    end
+
+    it 'should raise a human readable error message if the operation failed' do
+      allow(Nexus3::API).to receive(:execute_script).and_raise('Operation failed')
+      expect { instance.destroy }.to raise_error(Puppet::Error, /Error while deleting nexus3_cleanup_policy example/)
+    end
+  end
+
+  it 'should return false if it is not existing' do
+    # the dummy example isn't returned by self.instances
+    expect(instance.exists?).to be_falsey
+  end
+end

--- a/spec/unit/puppet/provider/nexus3_repository/ruby_spec.rb
+++ b/spec/unit/puppet/provider/nexus3_repository/ruby_spec.rb
@@ -100,12 +100,13 @@ describe type_class.provider(:ruby) do
             return null
           }
 
+          def cleanup = config.attributes('cleanup')
           def storage = config.attributes('storage')
           def proxy = config.attributes('proxy')
           def group = config.attributes('group')
           def maven = config.attributes('maven')
           def yum   = config.attributes('yum')
-          def docker= config.attributes('docker')
+          def docker = config.attributes('docker')
           def dockerProxy = config.attributes('dockerProxy')
           def apt = config.attributes('apt')
           def aptSigning = config.attributes('aptSigning')
@@ -117,6 +118,7 @@ describe type_class.provider(:ruby) do
             type: type,
             provider_type: providerType,
             online: config.isOnline(),
+            cleanup_policies: cleanup.get('policyName'),
             write_policy: storage.get('writePolicy'),
             blobstore_name: storage.get('blobStoreName'),
             strict_content_type_validation: storage.get('strictContentTypeValidation'),

--- a/spec/unit/puppet/type/nexus3_cleanup_policy_spec.rb
+++ b/spec/unit/puppet/type/nexus3_cleanup_policy_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:nexus3_cleanup_policy) do
+  subject { Puppet::Type.type(:nexus3_cleanup_policy) }
+
+  let(:required_values) do
+    {
+      name: 'foo',
+      last_downloaded: 7,
+    }
+  end
+  
+  describe 'by default' do
+    let(:instance) { subject.new(required_values) }
+
+    it { expect(instance[:format]).to eq(:all) }
+  end
+
+  it 'should not accept no criteria' do
+    expect {
+      subject.new(name: 'any', format: :all)
+    }.to raise_error(Puppet::ResourceError, /At least one criteria must be provided/)
+  end
+
+  it 'should validate format' do
+    expect {
+      subject.new(required_values.merge(format: 'invalid'))
+    }.to raise_error(Puppet::Error, /Invalid value "invalid"/)
+  end
+
+  specify 'should accept apt format policy' do
+    subject.new(required_values.merge(format: 'apt'))
+  end
+
+  describe :is_prerelease do
+    let(:prerel_values) do
+      required_values.merge(format: 'yum')
+    end
+    
+    specify 'should default to nil' do
+      expect(subject.new(required_values)[:is_prerelease]).to be nil
+    end
+
+    specify 'should accept :true for yum repos' do
+      expect { subject.new(prerel_values.merge(is_prerelease: :true)) }.to_not raise_error
+      expect(subject.new(prerel_values.merge(is_prerelease: :true))[:is_prerelease]).to be :true
+    end
+
+    specify 'should accept "true" for yum repos' do
+      expect { subject.new(prerel_values.merge(is_prerelease: 'true')) }.to_not raise_error
+      expect(subject.new(prerel_values.merge(is_prerelease: 'true'))[:is_prerelease]).to be :true
+    end
+
+    specify 'should accept :false for yum repos' do
+      expect { subject.new(prerel_values.merge(is_prerelease: :false)) }.to_not raise_error
+      expect(subject.new(prerel_values.merge(is_prerelease: :false))[:is_prerelease]).to be :false
+    end
+
+    specify 'should accept "false" for yum repos' do
+      expect { subject.new(prerel_values.merge(is_prerelease: 'false')) }.to_not raise_error
+      expect(subject.new(prerel_values.merge(is_prerelease: 'false'))[:is_prerelease]).to be :false
+    end
+  end
+
+  describe 'when removing' do
+    it { expect { subject.new(name: 'foo', ensure: :absent) }.to_not raise_error }
+  end
+end

--- a/spec/unit/puppet/type/nexus3_repository_spec.rb
+++ b/spec/unit/puppet/type/nexus3_repository_spec.rb
@@ -15,6 +15,7 @@ describe Puppet::Type.type(:nexus3_repository) do
     let(:instance) { subject.new(required_values) }
 
     it { expect(instance[:blobstore_name]).to eq('default') }
+    it { expect(instance[:cleanup_policies]).to eq nil }
     it { expect(instance[:online]).to eq(:true) }
     it { expect(instance[:strict_content_type_validation]).to eq(:true) }
     it { expect(instance[:version_policy]).to eq nil }
@@ -150,6 +151,24 @@ describe Puppet::Type.type(:nexus3_repository) do
       expect {
         subject.new(required_values.merge(provider_type: ''))
       }.to raise_error(Puppet::ResourceError, /Parameter provider_type failed/)
+    end
+  end
+
+  describe :cleanup_policies do
+    specify 'should accept a valid array of cleanup_policies' do
+      expect { subject.new(required_values.merge(cleanup_policies: ['policy-1', 'policy-2'])) }.to_not raise_error
+    end
+
+    specify 'should not accept empty string' do
+      expect {
+        subject.new(required_values.merge(cleanup_policies: ''))
+      }.to raise_error(Puppet::ResourceError, /Parameter cleanup_policies failed/)
+    end
+
+    specify 'should not accept a string as array' do
+      expect {
+        subject.new(required_values.merge(cleanup_policies: 'name1,name2'))
+      }.to raise_error(Puppet::ResourceError, /Parameter cleanup_policies failed/)
     end
   end
 


### PR DESCRIPTION
Implements #16.

This adds a new type `nexus3_cleanup_policy` for managing cleanup policies on Nexus 3. It also enhances `nexus3_repository` so that it can also configure the cleanup policies for hosted and proxy repos.