### PR TITLE
Prevent 'undefined method' error

### DIFF
--- a/lib/puppet/provider/nexus3_repository/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/read_config.erb
@@ -25,7 +25,7 @@ def infos = repositories.findResults { repository ->
     type: type,
     provider_type: providerType,
     online: config.isOnline(),
-    cleanup_policies: cleanup.get('policyName'),
+    cleanup_policies: cleanup.get('policyName') ? cleanup.get('policyName') : [],
     write_policy: storage.get('writePolicy'),
     blobstore_name: storage.get('blobStoreName'),
     strict_content_type_validation: storage.get('strictContentTypeValidation'),


### PR DESCRIPTION
When 'policyName' has never been set on a (new) repository
the insync? check fails with
```
Error: /Stage[main]/Profiles::Service::Nexus/Nexus3_repository[maven-central]/cleanup_policies: change from '' to [] failed: undefined method `sort' for "":String
```
Setting the default to [] resolves this issue.