### PR TITLE
Feature/admin password file set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+- Add `admin_password_file` parameter to `nexus3_admin_password` Type & Provider
+
 ## 0.3.0
 - Add support to apt, composer and yum repository types
 - Add support to docker specific attributes

--- a/README.md
+++ b/README.md
@@ -100,8 +100,20 @@ It will take care of check if the password needs to be changed and do the proper
 ```
 #!puppet
 nexus3_admin_password { 'admin_password':
-  old_password => 'admin123',
-  password     => '123admin',
+  old_password        => 'admin123',
+  password            => '123admin',
+}
+```
+
+As of Nexus version 3.17.0 the admin password now is randomly generated and put in the admin.password file on the server.
+[Changelog - Repository Manager 3.17.0](https://help.sonatype.com/repomanager3/release-notes/2019-release-notes#id-2019ReleaseNotes-RepositoryManager3.17.0)
+To automatically use that file to set your new password you can provide the `admin_password_file` parameter to point at that file for your install.
+
+```
+#!puppet
+nexus3_admin_password { 'admin_password':
+  admin_password_file => '/opt/sonatype-work/nexus3/admin.password',
+  password            => '123admin',
 }
 ```
 

--- a/lib/puppet/provider/nexus3_admin_password/ruby.rb
+++ b/lib/puppet/provider/nexus3_admin_password/ruby.rb
@@ -7,40 +7,32 @@ Puppet::Type.type(:nexus3_admin_password).provide(:ruby, parent: Puppet::Provide
     raise Puppet::Error, "There are more then 1 instance of '#{resources.values[0].class.name}': #{resources.keys.join(', ')}" if resources.size > 1
   end
 
-  def flush
-    if resource[:admin_password_file]
-      # needed for the admin.password file to be created
-      Nexus3::API.service.ensure_running
-      set_password = !File.exist?("#{resource[:admin_password_file]}.set")
-      if File.exist?(resource[:admin_password_file])
-        old_password = File.read(resource[:admin_password_file])
+  def password
+    Nexus3::API.service.ensure_running
+    Nexus3::API.service.client.request(Net::HTTP::Get, '', 'application/json', nil, 'admin', resource[:password]) do |response|
+      case response
+      when Net::HTTPOK, Net::HTTPNoContent
+        'ok'
+      else
+        'nok'
       end
-    else
-      old_password = resource[:old_password]
-      set_password = old_password != resource[:password]
-    end
-
-    if set_password
-      Nexus3::API.service.ensure_running
-      Nexus3::API.service.client.request(Net::HTTP::Get, '', 'application/json', nil, 'admin', resource[:password]) do |response|
-        case response
-          when Net::HTTPOK, Net::HTTPNoContent
-            Puppet.debug('Admin password is already with the correct value')
-          else
-            Puppet.debug('Admin password is with a incorrect value. Trying to set the correct one')
-            command_name = Nexus3::API.upload_script("security.securitySystem.changePassword('admin', '#{ resource[:password] }')", 'admin', old_password)
-            begin
-              Nexus3::API.run_command(command_name, 'admin', old_password)
-              Nexus3::API.delete_command(command_name, 'admin', resource[:password])
-            rescue
-              Nexus3::API.delete_command(command_name, 'admin', old_password)
-            end
-            Nexus3::Config.reset
-        end
-      end
-      File.rename(resource[:admin_password_file], "#{resource[:admin_password_file]}.set") if resource[:admin_password_file]
     end
   end
 
-  mk_resource_methods
+  def password=(value)
+    Puppet.debug('Admin password is with a incorrect value. Trying to set the correct one.')
+    if resource[:admin_password_file] && File.exist?(resource[:admin_password_file])
+      old_password = File.read(resource[:admin_password_file])
+    else
+      old_password = resource[:old_password]
+    end
+    command_name = Nexus3::API.upload_script("security.securitySystem.changePassword('admin', '#{ resource[:password] }')", 'admin', old_password)
+    begin
+      Nexus3::API.run_command(command_name, 'admin', old_password)
+      Nexus3::API.delete_command(command_name, 'admin', resource[:password])
+    rescue
+      Nexus3::API.delete_command(command_name, 'admin', old_password)
+    end
+    Nexus3::Config.reset
+  end
 end

--- a/lib/puppet/provider/nexus3_admin_password/ruby.rb
+++ b/lib/puppet/provider/nexus3_admin_password/ruby.rb
@@ -8,7 +8,19 @@ Puppet::Type.type(:nexus3_admin_password).provide(:ruby, parent: Puppet::Provide
   end
 
   def flush
-    if resource[:old_password] != resource[:password]
+    if resource[:admin_password_file]
+      # needed for the admin.password file to be created
+      Nexus3::API.service.ensure_running
+      set_password = !File.exist?("#{resource[:admin_password_file]}.set")
+      if File.exist?(resource[:admin_password_file])
+        old_password = File.read(resource[:admin_password_file])
+      end
+    else
+      old_password = resource[:old_password]
+      set_password = old_password != resource[:password]
+    end
+
+    if set_password
       Nexus3::API.service.ensure_running
       Nexus3::API.service.client.request(Net::HTTP::Get, '', 'application/json', nil, 'admin', resource[:password]) do |response|
         case response
@@ -16,16 +28,17 @@ Puppet::Type.type(:nexus3_admin_password).provide(:ruby, parent: Puppet::Provide
             Puppet.debug('Admin password is already with the correct value')
           else
             Puppet.debug('Admin password is with a incorrect value. Trying to set the correct one')
-            command_name = Nexus3::API.upload_script("security.securitySystem.changePassword('admin','#{ resource[:password] }')", 'admin', resource[:old_password])
+            command_name = Nexus3::API.upload_script("security.securitySystem.changePassword('admin', '#{ resource[:password] }')", 'admin', old_password)
             begin
-              Nexus3::API.run_command(command_name, 'admin', resource[:old_password])
+              Nexus3::API.run_command(command_name, 'admin', old_password)
               Nexus3::API.delete_command(command_name, 'admin', resource[:password])
             rescue
-              Nexus3::API.delete_command(command_name, 'admin', resource[:old_password])
+              Nexus3::API.delete_command(command_name, 'admin', old_password)
             end
             Nexus3::Config.reset
         end
       end
+      File.rename(resource[:admin_password_file], "#{resource[:admin_password_file]}.set") if resource[:admin_password_file]
     end
   end
 

--- a/lib/puppet/type/nexus3_admin_password.rb
+++ b/lib/puppet/type/nexus3_admin_password.rb
@@ -7,6 +7,10 @@ Puppet::Type.newtype(:nexus3_admin_password) do
     desc 'Resource ID.'
   end
 
+  newparam(:admin_password_file) do
+    desc 'Use this admin.password file on a new setup.'
+  end
+
   newparam(:old_password) do
     desc 'The old password of the user.'
 

--- a/lib/puppet/type/nexus3_admin_password.rb
+++ b/lib/puppet/type/nexus3_admin_password.rb
@@ -33,6 +33,10 @@ Puppet::Type.newtype(:nexus3_admin_password) do
       '[check if the correct password is assigned]'
     end
 
+    def insync?(is)
+      is == 'ok'
+    end
+
     validate do |value|
       raise ArgumentError, 'password must be provided.' if value.empty?
     end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "wandenberg/nexus3_rest",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Wandenberg Peixoto",
   "summary": "Puppet directives to configure Nexus3 Repository Manager OSS",
   "license": "MIT",


### PR DESCRIPTION
As of Nexus version 3.17.0 the admin password now is randomly generated and put in the admin.password file.
This change allows using the password from that file to set the new admin password.