### PR TITLE
Rename admin.password file after setting pwd

### DIFF
--- a/lib/puppet/provider/nexus3_admin_password/ruby.rb
+++ b/lib/puppet/provider/nexus3_admin_password/ruby.rb
@@ -39,5 +39,6 @@ Puppet::Type.type(:nexus3_admin_password).provide(:ruby, parent: Puppet::Provide
     end
     Nexus3::API.delete_command(command_name, 'admin', old_password)
     Nexus3::Config.reset
+    File.rename(resource[:admin_password_file], "#{resource[:admin_password_file]}.set") if resource[:admin_password_file] && File.exist?(resource[:admin_password_file])
   end
 end


### PR DESCRIPTION
The admin.password should be renamed (or removed) so the check
```
return 'nok' if resource[:admin_password_file] && File.exist?(resource[:admin_password_file])
```
can be useful