### PR TITLE
Changed blobstore creation code to be compatible with Nexus 3.20 and up.

### DIFF
--- a/lib/puppet/provider/nexus3_blobstore/templates/create_config.erb
+++ b/lib/puppet/provider/nexus3_blobstore/templates/create_config.erb
@@ -1,9 +1,25 @@
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
+
 def blobStoreManager = container.lookup(org.sonatype.nexus.blobstore.api.BlobStoreManager.class.name)
-def config = new org.sonatype.nexus.blobstore.api.BlobStoreConfiguration([
-  name: '<%= resource[:name] %>',
-  type: '<%= resource[:type] %>',
-  attributes: [:],
-])
+
+// -----
+// Important: BlobStoreConfiguration was a class in <= 3.19 and became
+// an interface in >= 3.20.  Code cannot be (easily) made backwards
+// compatible.
+// -----
+
+// Compatible with <= 3.19
+//config = new BlobStoreConfiguration([
+//  name: '<%= resource[:name] %>',
+//  type: '<%= resource[:type] %>',
+//  attributes: [:],
+//])
+
+// Compatible with >= 3.20
+BlobStoreConfiguration config = blobStoreManager.newConfiguration()
+config.setName('<%= resource[:name] %>')
+config.setType('<%= resource[:type] %>')
+config.setAttributes([:])
 
 <%- if resource[:soft_quota_enabled] == :true -%>
 config.attributes.blobStoreQuotaConfig = [


### PR DESCRIPTION
Note: This BREAKS compatibility with Nexus 3.19 and below.

In 3.19 and below BlobStoreConfiguration was a class. In 3.20 and above it is an interface. See   [3e1948a092fcb8ef184b96ee8b36a7520c0d49ea](https://github.com/sonatype/nexus-public/commit/3e1948a092fcb8ef184b96ee8b36a7520c0d49ea)

Short of using Reflection, I don't see an easy way to make this code compatible with both.  Changing a class to an interface in a minor release seems pretty dubious to me, but that's where we find ourselves.

This relates to #29.