### PR TITLE
Add support for configuration of cache settings for proxied repositories

### DIFF
--- a/lib/puppet/provider/nexus3_repository/templates/create_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/create_config.erb
@@ -20,6 +20,8 @@ storage.set('writePolicy', '<%= WRITE_POLICY_MAPPING[resource[:write_policy]] %>
 <%- elsif resource[:type] == :proxy -%>
 def proxy = config.attributes('proxy')
 proxy.set('remoteUrl', '<%= resource[:remote_url] %>')
+proxy.set('contentMaxAge', '<%= resource[:content_max_age] %>')
+proxy.set('metadataMaxAge', '<%= resource[:metadata_max_age] %>')
 def httpclient = config.attributes('httpclient');
 httpclient.set('blocked', '<%= resource[:blocked] %>');
 httpclient.set('autoBlock', '<%= resource[:auto_block] %>');

--- a/lib/puppet/provider/nexus3_repository/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/read_config.erb
@@ -33,6 +33,8 @@ def infos = repositories.findResults { repository ->
     blobstore_name: storage.get('blobStoreName'),
     strict_content_type_validation: storage.get('strictContentTypeValidation'),
     remote_url: proxy.get('remoteUrl'),
+    content_max_age: proxy.get('contentMaxAge'),
+    metadata_max_age: proxy.get('metadataMaxAge'),
     version_policy: maven.get('versionPolicy')?.toLowerCase(),
     layout_policy: maven.get('layoutPolicy')?.toLowerCase(),
     auto_block: httpclient.get('autoBlock'),

--- a/lib/puppet/provider/nexus3_repository/templates/write_config.erb
+++ b/lib/puppet/provider/nexus3_repository/templates/write_config.erb
@@ -13,6 +13,8 @@ config.attributes('httpclient').remove('authentication')
 <%- elsif resource[:type] == :proxy -%>
 def proxy = config.attributes('proxy')
 proxy.set('remoteUrl', '<%= resource[:remote_url] %>')
+proxy.set('contentMaxAge', '<%= resource[:content_max_age] %>')
+proxy.set('metadataMaxAge', '<%= resource[:metadata_max_age] %>')
 def httpclient = config.attributes('httpclient');
 httpclient.set('blocked', '<%= resource[:blocked] %>');
 httpclient.set('autoBlock', '<%= resource[:auto_block] %>');

--- a/lib/puppet/type/nexus3_repository.rb
+++ b/lib/puppet/type/nexus3_repository.rb
@@ -158,6 +158,16 @@ Puppet::Type.newtype(:nexus3_repository) do
          'Only useful for proxy-type repositories.'
   end
 
+  newproperty(:content_max_age) do
+    desc 'How long (in minutes) to cache artifacts before rechecking the remote repository. Release repositories should use -1. ' \
+         'Only useful for proxy-type repositories.'
+  end
+
+  newproperty(:metadata_max_age) do
+    desc 'How long (in minutes) to cache metadata before rechecking the remote repository. ' \
+         'Only useful for proxy-type repositories.'
+  end
+
   newproperty(:remote_auth_type) do
     desc 'Define the type of authentication to be used to the remote repository.'
     defaultto do @resource[:provider_type] == :maven2 ? :username : :none end


### PR DESCRIPTION
Allow settings contentMaxAge and metadataMaxAge for proxy repos. We use this to lower the metadata cache for specific apt repos.