### PR TITLE
Ensure "group_*" attributes are not "Undef". Fixes #65.

### DIFF
--- a/lib/puppet/provider/nexus3_ldap/templates/read_config.erb
+++ b/lib/puppet/provider/nexus3_ldap/templates/read_config.erb
@@ -40,11 +40,11 @@ def infos = ldapConfigurations.collect { ldapConfiguration ->
     user_subtree: mapping.isUserSubtree(),
     user_member_of_attribute: ensureDefault(mapping.getUserMemberOfAttribute()),
 
-    group_base_dn: mapping.getGroupBaseDn(),
-    group_id_attribute: mapping.getGroupIdAttribute(),
-    group_member_attribute: mapping.getGroupMemberAttribute(),
-    group_member_format: mapping.getGroupMemberFormat(),
-    group_object_class: mapping.getGroupObjectClass(),
+    group_base_dn: mapping.getGroupBaseDn() ?: '',
+    group_id_attribute: mapping.getGroupIdAttribute() ?: '',
+    group_member_attribute: mapping.getGroupMemberAttribute() ?: '',
+    group_member_format: mapping.getGroupMemberFormat() ?: '',
+    group_object_class: mapping.getGroupObjectClass() ?: '',
     group_subtree: mapping.isGroupSubtree(),
 
     ldap_filter: mapping.getLdapFilter(),


### PR DESCRIPTION
Set `group_*` attributes to empty string in case the methods to get those values return `null`.
Fixes #65.